### PR TITLE
HYDRAN-2566: Force fresh WSO2 token

### DIFF
--- a/src/main/java/se/sundsvall/paratransit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptor.java
+++ b/src/main/java/se/sundsvall/paratransit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptor.java
@@ -5,8 +5,9 @@ import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 
-import static java.util.Objects.nonNull;
+import static java.util.Objects.isNull;
 import static se.sundsvall.paratransit.integration.operaton.configuration.OperatonConfiguration.CLIENT_ID;
 
 /**
@@ -15,24 +16,36 @@ import static se.sundsvall.paratransit.integration.operaton.configuration.Operat
  * instance targets Operaton (see {@link OperatonExternalTaskClientConfiguration}); the Camunda instance polls its
  * engine
  * directly without a token.
+ * <p>
+ * An interceptor never sees the response, so it cannot detect a 401 and evict a stale token afterwards (unlike the
+ * Feign
+ * path). To stay robust against tokens that WSO2 invalidates server-side before their nominal expiry (gateway restart,
+ * revocation, clock drift), every poll evicts the cached authorized client before authorizing, forcing the manager to
+ * obtain a freshly issued token instead of reusing the cached one.
  */
 class OperatonExternalTaskAuthInterceptor implements ClientRequestInterceptor {
 
 	private static final String PRINCIPAL = "operaton-external-task-client";
 
 	private final OAuth2AuthorizedClientManager authorizedClientManager;
+	private final OAuth2AuthorizedClientService authorizedClientService;
 
-	OperatonExternalTaskAuthInterceptor(final OAuth2AuthorizedClientManager authorizedClientManager) {
+	OperatonExternalTaskAuthInterceptor(final OAuth2AuthorizedClientManager authorizedClientManager, final OAuth2AuthorizedClientService authorizedClientService) {
 		this.authorizedClientManager = authorizedClientManager;
+		this.authorizedClientService = authorizedClientService;
 	}
 
 	@Override
 	public void intercept(final ClientRequestContext requestContext) {
+		authorizedClientService.removeAuthorizedClient(CLIENT_ID, PRINCIPAL);
+
 		final var authorizedClient = authorizedClientManager.authorize(
 			OAuth2AuthorizeRequest.withClientRegistrationId(CLIENT_ID).principal(PRINCIPAL).build());
 
-		if (nonNull(authorizedClient)) {
-			requestContext.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authorizedClient.getAccessToken().getTokenValue());
+		if (isNull(authorizedClient)) {
+			throw new IllegalStateException("Could not obtain a WSO2 access token for client registration '" + CLIENT_ID + "'; external task polling cannot authenticate against the Operaton gateway");
 		}
+
+		requestContext.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authorizedClient.getAccessToken().getTokenValue());
 	}
 }

--- a/src/main/java/se/sundsvall/paratransit/integration/operaton/configuration/OperatonExternalTaskClientConfiguration.java
+++ b/src/main/java/se/sundsvall/paratransit/integration/operaton/configuration/OperatonExternalTaskClientConfiguration.java
@@ -25,6 +25,6 @@ public class OperatonExternalTaskClientConfiguration {
 		final var authorizedClientManager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
 		authorizedClientManager.setAuthorizedClientProvider(OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build());
 
-		return new OperatonExternalTaskAuthInterceptor(authorizedClientManager);
+		return new OperatonExternalTaskAuthInterceptor(authorizedClientManager, authorizedClientService);
 	}
 }

--- a/src/test/java/se/sundsvall/paratransit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
+++ b/src/test/java/se/sundsvall/paratransit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
@@ -4,14 +4,18 @@ import java.time.Instant;
 import org.camunda.bpm.client.interceptor.ClientRequestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -20,8 +24,14 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class OperatonExternalTaskAuthInterceptorTest {
 
+	private static final String CLIENT_ID = "operaton";
+	private static final String PRINCIPAL = "operaton-external-task-client";
+
 	@Mock
 	private OAuth2AuthorizedClientManager authorizedClientManagerMock;
+
+	@Mock
+	private OAuth2AuthorizedClientService authorizedClientServiceMock;
 
 	@Mock
 	private ClientRequestContext requestContextMock;
@@ -34,16 +44,38 @@ class OperatonExternalTaskAuthInterceptorTest {
 		when(authorizedClient.getAccessToken()).thenReturn(accessToken);
 		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);
 
-		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock).intercept(requestContextMock);
+		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock, authorizedClientServiceMock).intercept(requestContextMock);
 
 		verify(requestContextMock).addHeader("Authorization", "Bearer the-token");
 	}
 
 	@Test
-	void doesNotAddHeaderWhenNotAuthorized() {
+	void evictsCachedTokenBeforeEveryAuthorize() {
+		final var issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+		final var accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "the-token", issuedAt, issuedAt.plusSeconds(60));
+		final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+		when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);
+
+		final var interceptor = new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock, authorizedClientServiceMock);
+		interceptor.intercept(requestContextMock);
+		interceptor.intercept(requestContextMock);
+
+		final InOrder inOrder = inOrder(authorizedClientServiceMock, authorizedClientManagerMock);
+		inOrder.verify(authorizedClientServiceMock).removeAuthorizedClient(CLIENT_ID, PRINCIPAL);
+		inOrder.verify(authorizedClientManagerMock).authorize(any(OAuth2AuthorizeRequest.class));
+		inOrder.verify(authorizedClientServiceMock).removeAuthorizedClient(CLIENT_ID, PRINCIPAL);
+		inOrder.verify(authorizedClientManagerMock).authorize(any(OAuth2AuthorizeRequest.class));
+	}
+
+	@Test
+	void throwsWhenNoTokenCanBeObtained() {
 		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(null);
 
-		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock).intercept(requestContextMock);
+		final var interceptor = new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock, authorizedClientServiceMock);
+
+		assertThatExceptionOfType(IllegalStateException.class)
+			.isThrownBy(() -> interceptor.intercept(requestContextMock));
 
 		verifyNoInteractions(requestContextMock);
 	}


### PR DESCRIPTION
* Force fresh WSO2 token per external-task poll and fail loud when none can be obtained

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
